### PR TITLE
feat: Add 45D Drive Map CA entry

### DIFF
--- a/limetech/45d-drivemap.xml
+++ b/limetech/45d-drivemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Containers>
+<Plugin>True</Plugin>
+<PluginURL>https://github.com/unraid/45d-drivemap/releases/latest/download/45d-drivemap.plg</PluginURL>
+<PluginAuthor>45Drives + Unraid</PluginAuthor>
+<Beta>False</Beta>
+<Category>Tools:System</Category>
+<Name>45D Drive Map</Name>
+<MinVer>6.12.0</MinVer>
+<Requires>45Drives system, such as an X-15 or HL-15</Requires>
+<Description>
+Embed the 45Drives disk map UI directly in Unraid's Main page and generate map/server metadata on the Unraid host. This plugin is supported on 45Drives systems only, such as X-15 and HL-15 systems.
+</Description>
+<Support>https://github.com/unraid/45d-drivemap/issues</Support>
+<IconFA>th</IconFA>
+</Containers>


### PR DESCRIPTION
## Summary

Adds a Community Applications template for the 45D Drive Map Unraid plugin under `limetech/`.

The entry uses the plugin's stable latest release URL:

`https://github.com/unraid/45d-drivemap/releases/latest/download/45d-drivemap.plg`

It also:

- marks the plugin as requiring a 45Drives system, such as an X-15 or HL-15
- notes in the description that the plugin is supported on 45Drives systems only
- sets the support target to the plugin issue tracker so the Plugins tab support action points users to the correct place

## Related issue

Addresses unraid/45d-drivemap#8.

## Validation

- `xmllint --noout limetech/45d-drivemap.xml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plugin manifest for "45D Drive Map" providing metadata: download URL, author, category (Tools:System), min Unraid version 6.12.0+, hardware/system requirement text, UI description, support link, beta flag, and icon identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->